### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plug 'npxbr/gruvbox.nvim'
 Using `packer`
 
 ```
-use {"npxbr/gruvbox.nvim", requires = {"tjdevries/colorbuddy.vim"}}
+use {"npxbr/gruvbox.nvim", requires = {"tjdevries/colorbuddy.nvim"}}
 ```
 
 # Usage


### PR DESCRIPTION
`colorbuddy.vim` instead of the correct `colorbuddy.nvim`