### PR TITLE
Fix tabline always being inverted

### DIFF
--- a/lua/gruvbox/settings.lua
+++ b/lua/gruvbox/settings.lua
@@ -27,7 +27,7 @@ local styles = {
   undercurl = "undercurl",
   invert_signs = "",
   invert_selection = "inverse",
-  invert_tabline = "inverse",
+  invert_tabline = "",
   italic_comments = "italic",
   italic_strings = "NONE",
 }


### PR DESCRIPTION
After switching to this plugin, I noticed that my tabline looked off, and I traced it to the inverse flag always being on. This fixes it by changing to the same scheme used by `invert_signs`