### PR TITLE
highlight LspCodeLens like comments

### DIFF
--- a/lua/gruvbox/plugins/highlights.lua
+++ b/lua/gruvbox/plugins/highlights.lua
@@ -220,6 +220,7 @@ local plugins = lush(function()
     GitSignsDelete {base.GruvboxRedSign},
     GitSignsCurrentLineBlame {base.NonText},
     -- LSP
+    LspCodeLens {base.GruvboxGray},
     LspDiagnosticsDefaultError {base.GruvboxRed},
     LspDiagnosticsSignError {base.GruvboxRedSign},
     LspDiagnosticsUnderlineError {base.GruvboxRedUnderline},


### PR DESCRIPTION
This highlight group is used for code lenses of the built-in lsp client.

Before:
![image](https://user-images.githubusercontent.com/12595971/126902669-75ccd351-a77d-43d6-97d9-83b829bf95ea.png)

Notice how the virtual text of the code lens (`int -> int`) looks like real text/code.

After:
![image](https://user-images.githubusercontent.com/12595971/126902635-4b0431b7-9968-4542-b253-04044acd861a.png)
