### PR TITLE
highlight rust documentation comments differently than normal comments

### DIFF
--- a/lua/gruvbox/languages.lua
+++ b/lua/gruvbox/languages.lua
@@ -484,7 +484,8 @@ local rust = lush(function()
     rustEnum {base.GruvboxAqua},
     rustStructure {base.GruvboxAqua},
     rustModPathSep {base.GruvboxFg2},
-    rustCommentLineDoc {base.Comment},
+    rustCommentLineDoc {base.GruvboxOrange},
+    rustCommentBlockDoc {base.GruvboxOrange},
     rustDefault {base.GruvboxAqua},
   }
 end)


### PR DESCRIPTION
in the original gruvbox they would be in orange.